### PR TITLE
Adds option to add a sidebar A3 highlight 

### DIFF
--- a/layouts/Layout.vue
+++ b/layouts/Layout.vue
@@ -1,0 +1,33 @@
+<template>
+  <ParentLayout>
+    <template #sidebar-bottom>
+      <section v-if="$themeConfig && $themeConfig.latestVersionPromo"
+        class="layout-note"
+      >
+        <p>
+          <a href="https://v3.docs.apostrophecms.org/">Learn about Apostrophe 3. 🆕</a>
+        </p>
+      </section>
+    </template>
+  </ParentLayout>
+</template>
+
+<script>
+import ParentLayout from '@parent-theme/layouts/Layout.vue'
+
+export default {
+  name: 'Layout',
+  components: {
+    ParentLayout
+  }
+}
+</script>
+
+<style lang="stylus" scoped>
+  .layout-note
+    background-color: $badgeTipColor
+    padding 0.35rem 1rem 0.35rem 1.25rem
+
+    a
+      color: white
+</style>

--- a/layouts/Layout.vue
+++ b/layouts/Layout.vue
@@ -5,7 +5,7 @@
         class="layout__promo"
       >
         <span>🌟</span>
-        <a href="https://v3.docs.apostrophecms.org">Learn about Apostrophe 3.</a>
+        <a href="https://v3.docs.apostrophecms.org">Learn About Apostrophe 3</a>
       </section>
     </template>
   </ParentLayout>

--- a/layouts/Layout.vue
+++ b/layouts/Layout.vue
@@ -2,11 +2,10 @@
   <ParentLayout>
     <template #sidebar-bottom>
       <section v-if="$themeConfig && $themeConfig.latestVersionPromo"
-        class="layout-note"
+        class="layout__promo"
       >
-        <p>
-          <a href="https://v3.docs.apostrophecms.org/">Learn about Apostrophe 3. 🆕</a>
-        </p>
+        <span>🌟</span>
+        <a href="https://v3.docs.apostrophecms.org">Learn about Apostrophe 3.</a>
       </section>
     </template>
   </ParentLayout>
@@ -24,10 +23,19 @@ export default {
 </script>
 
 <style lang="stylus" scoped>
-  .layout-note
-    background-color: $badgeTipColor
-    padding 0.35rem 1rem 0.35rem 1.25rem
+  .layout__promo
+    display: inline-block;
+    margin-left: 0.75rem;
+    padding: 0.35rem 1rem .35rem 0.5rem;
+    border-radius: 10px;
+    background-color: #e3dbff;
+    font-size: 17px;
 
     a
-      color: white
+      display: inline
+      font-weight: 600
+      color: inherit
+
+    span
+      margin-right: 0.5rem
 </style>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vuepress-theme-apostrophe",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Enabled in the Vuepress site's themeConfig object with `latestVersionPromo: true,`. Adds the callout message shown in the sidebar here:

![Screen Shot 2021-11-29 at 3 17 44 PM](https://user-images.githubusercontent.com/1155984/143944432-fd1fd6bc-80e7-4654-9f20-0f7f6d9540bd.png)
